### PR TITLE
Update CMake minimum version to 3.10

### DIFF
--- a/servant/CMakeLists.txt
+++ b/servant/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(servant)
 

--- a/servant/script/cmake_demo/CMakeLists.txt
+++ b/servant/script/cmake_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 project(Demo-DemoServer)
 

--- a/servant/script/cmake_demo/src/CMakeLists.txt
+++ b/servant/script/cmake_demo/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 project(DemoApp-DemoServer)
 

--- a/servant/script/cmake_http_demo/CMakeLists.txt
+++ b/servant/script/cmake_http_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 project(Demo-DemoServer)
 

--- a/servant/script/cmake_http_demo/src/CMakeLists.txt
+++ b/servant/script/cmake_http_demo/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 project(DemoApp-DemoServer)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(tools)
 
 include_directories(${util_SOURCE_DIR}/include)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(util)
 
 if(WIN32)


### PR DESCRIPTION
Update the minimum required CMake version across multiple project files to ensure compatibility with newer features and improvements.